### PR TITLE
ARROW-1752: Add GPU packages for Debian and Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,22 @@ matrix:
     before_install:
     install:
     script:
-    - (cd cpp-linux && travis_wait 40 rake apt:build PARALLEL=yes DEBUG=no)
+    - (cd cpp-linux && travis_wait 40 rake apt:build APT_TARGETS=debian-stretch,ubuntu-trusty,ubuntu-xenial PARALLEL=yes DEBUG=no)
+    deploy:
+      provider: bintray
+      file: cpp-linux/apt/descriptor.json
+      user: kou
+      on:
+        all_branches: true
+      key:
+        secure: "XXRJFBIOGS9urF047KcGlCqnMwKWa/EhW1Q2A3JGDd7Au+NHd99Rl/iRbtd44xVnfhosKGEH9mBGrqIZb/Tfn3RTtSi/KvN2RIoWmdsc3Kxk1eKd6O9kCLo4Y1GqboK8JVIHD4OYiyoVoFmnYLuinfdtrZrME5aU4pENnvwR3E0qvjhnhfwRG/Mtb93ePAqzih95gT7S0VWlsBV3FPa21aY7ctFteUP+DdqXZX1BmUnJB6cBxUGjpL8Bu8O/mt3l3yIrT9UkWM1g75l7zrP354x5+AMbHWBv7yGFa+JvbB+LXkrE2dV6j3Upf6ChnQKoTKv5Ur5LJBbCHyRieW3/uE/h47IR3c/3mRnhoSIl4QX7UoQkvTwHSE1Xpry3I2jE0WVHmq9NqT4iaxIv5oga+3I/W6h8brV3yCYfVUi1F90aRlnZHsCDmtAqzW1u9s1xqkO4z4/dennI0gniEn4kWfx0I7aCQQI/XmDri/33uTINprwBB5eHt6a7WGysrcO6Mv5I8EFEAJ5vkx2mDVw+rDFC7/R8YNA77PcJABlF7G/ZajcHqPnN5uyJC+P2m6JyHO+kTHemjW8pgf5vKvdNzdTN1AVFSO9Mv4O3NPyaADRl9DCCcqAk2LwL+SYqCVvIXu98Mb6uEoSOb+ZnpvseyydxNB6DtQSVtVUNdis5Ibw="
+  - language: ruby
+    os: linux
+    before_script:
+    before_install:
+    install:
+    script:
+    - (cd cpp-linux && travis_wait 40 rake apt:build APT_TARGETS=ubuntu-zesty,ubuntu-artful PARALLEL=yes DEBUG=no)
     deploy:
       provider: bintray
       file: cpp-linux/apt/descriptor.json

--- a/cpp-linux/apt/debian-stretch/Dockerfile
+++ b/cpp-linux/apt/debian-stretch/Dockerfile
@@ -21,6 +21,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 ARG DEBUG
 
+RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
+
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
@@ -37,6 +39,7 @@ RUN \
     libglib2.0-doc \
     libjemalloc-dev \
     lsb-release \
+    nvidia-cuda-toolkit \
     pkg-config \
     python3-dev \
     python3-numpy && \

--- a/cpp-linux/apt/ubuntu-artful/Dockerfile
+++ b/cpp-linux/apt/ubuntu-artful/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     libglib2.0-doc \
     libjemalloc-dev \
     lsb-release \
+    nvidia-cuda-toolkit \
     pkg-config \
     python3-dev \
     python3-numpy && \

--- a/cpp-linux/apt/ubuntu-xenial/Dockerfile
+++ b/cpp-linux/apt/ubuntu-xenial/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     libglib2.0-doc \
     libjemalloc-dev \
     lsb-release \
+    nvidia-cuda-toolkit \
     pkg-config \
     python3-dev \
     python3-numpy && \

--- a/cpp-linux/apt/ubuntu-zesty/Dockerfile
+++ b/cpp-linux/apt/ubuntu-zesty/Dockerfile
@@ -37,6 +37,7 @@ RUN \
     libglib2.0-doc \
     libjemalloc-dev \
     lsb-release \
+    nvidia-cuda-toolkit \
     pkg-config \
     python3-dev \
     python3-numpy && \

--- a/cpp-linux/debian/changelog
+++ b/cpp-linux/debian/changelog
@@ -1,3 +1,11 @@
+apache-arrow (0.7.1-2) unstable; urgency=low
+
+  * Add libarrow-gpu0 and libarrow-gpu-dev.
+
+  * Add libarrow-python-dev.
+
+ -- Kouhei Sutou <kou@clear-code.com>  Sun, 29 Oct 2017 21:59:13 +0900
+
 apache-arrow (0.7.1-1) unstable; urgency=low
 
   * New upstream release.

--- a/cpp-linux/debian/control
+++ b/cpp-linux/debian/control
@@ -12,6 +12,7 @@ Build-Depends:
   libjemalloc-dev,
   python3-dev,
   python3-numpy,
+  nvidia-cuda-toolkit,
   libgirepository1.0-dev,
   gtk-doc-tools,
   gobject-introspection
@@ -45,7 +46,22 @@ Depends:
   python3-numpy
 Description: Apache Arrow is a data processing library for analysis
  .
- This package provides library files for Python.
+ This package provides library files for Python support.
+
+Package: libarrow-gpu0
+Section: libs
+Architecture: any
+Multi-Arch: same
+Pre-Depends: ${misc:Pre-Depends}
+Depends:
+  ${misc:Depends},
+  ${shlibs:Depends},
+  libarrow0 (= ${binary:Version}),
+  libnvidia-fatbinaryloader,
+  libcuda1
+Description: Apache Arrow is a data processing library for analysis
+ .
+ This package provides library files for GPU support.
 
 Package: libarrow-dev
 Section: libdevel
@@ -57,6 +73,30 @@ Depends:
 Description: Apache Arrow is a data processing library for analysis
  .
  This package provides header files.
+
+Package: libarrow-python-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends:
+  ${misc:Depends},
+  libarrow-dev (= ${binary:Version}),
+  libarrow-python0 (= ${binary:Version})
+Description: Apache Arrow is a data processing library for analysis
+ .
+ This package provides header files for Python support.
+
+Package: libarrow-gpu-dev
+Section: libdevel
+Architecture: any
+Multi-Arch: same
+Depends:
+  ${misc:Depends},
+  libarrow-dev (= ${binary:Version}),
+  libarrow-gpu0 (= ${binary:Version})
+Description: Apache Arrow is a data processing library for analysis
+ .
+ This package provides header files for GPU support.
 
 Package: libarrow-glib0
 Section: libs

--- a/cpp-linux/debian/libarrow-dev.install
+++ b/cpp-linux/debian/libarrow-dev.install
@@ -1,7 +1,5 @@
 usr/include/arrow/
 usr/lib/*/libarrow.a
-usr/lib/*/libarrow_*.a
 usr/lib/*/libarrow.so
-usr/lib/*/libarrow_*.so
 usr/lib/*/pkgconfig/arrow.pc
 usr/lib/*/pkgconfig/arrow-compute.pc

--- a/cpp-linux/debian/libarrow-gpu-dev.install
+++ b/cpp-linux/debian/libarrow-gpu-dev.install
@@ -1,0 +1,3 @@
+usr/lib/*/libarrow_gpu.a
+usr/lib/*/libarrow_gpu.so
+usr/lib/*/pkgconfig/arrow-gpu.pc

--- a/cpp-linux/debian/libarrow-gpu0.install
+++ b/cpp-linux/debian/libarrow-gpu0.install
@@ -1,0 +1,1 @@
+usr/lib/*/libarrow_gpu.so.*

--- a/cpp-linux/debian/libarrow-python-dev.install
+++ b/cpp-linux/debian/libarrow-python-dev.install
@@ -1,0 +1,3 @@
+usr/lib/*/libarrow_python.a
+usr/lib/*/libarrow_python.so
+usr/lib/*/pkgconfig/arrow-python.pc

--- a/cpp-linux/debian/rules
+++ b/cpp-linux/debian/rules
@@ -20,7 +20,8 @@ override_dh_auto_configure:
 	  -DARROW_BUILD_TESTS=OFF \
 	  -DARROW_PYTHON=ON \
 	  -DPythonInterp_FIND_VERSION=ON \
-	  -DPythonInterp_FIND_VERSION_MAJOR=3
+	  -DPythonInterp_FIND_VERSION_MAJOR=3 \
+	  -DARROW_GPU=ON
 	dh_auto_configure \
 	  --sourcedirectory=c_glib \
 	  --builddirectory=c_glib_build \


### PR DESCRIPTION
We need two Travis CI entry to build all .debs because we don't have enough space to build all .debs in one Travis CI entry.