### PR TITLE
Fix .typelib path for Ubuntu trusty

### DIFF
--- a/cpp-linux/debian.ubuntu-trusty/changelog
+++ b/cpp-linux/debian.ubuntu-trusty/changelog
@@ -1,3 +1,10 @@
+apache-arrow (0.8.0-2) unstable; urgency=low
+
+  * Fix .typelib path.
+    Reported by Mike Sam. Thanks!!!
+
+ -- Kouhei Sutou <kou@clear-code.com>  Thu, 25 Jan 2018 21:44:11 +0900
+
 apache-arrow (0.8.0-1) unstable; urgency=low
 
   * New upstream release.

--- a/cpp-linux/debian.ubuntu-trusty/gir1.2-arrow-1.0.install
+++ b/cpp-linux/debian.ubuntu-trusty/gir1.2-arrow-1.0.install
@@ -1,1 +1,1 @@
-usr/lib/*/girepository-1.0/
+usr/lib/girepository-1.0/

--- a/cpp-linux/debian.ubuntu-trusty/rules
+++ b/cpp-linux/debian.ubuntu-trusty/rules
@@ -44,6 +44,8 @@ override_dh_auto_install:
 	dh_auto_install				\
 	  --sourcedirectory=c_glib		\
 	  --builddirectory=c_glib_build
+	mv debian/tmp/usr/lib/*/girepository-1.0/	\
+	  debian/tmp/usr/lib/
 
 # disable 'make check'.
 override_dh_auto_test:


### PR DESCRIPTION
Reported by Mike Sam. Thanks!!!