### PR TITLE
[deb] Stop to use -Wdate-time

### DIFF
--- a/cpp-linux/debian.ubuntu-trusty/rules
+++ b/cpp-linux/debian.ubuntu-trusty/rules
@@ -6,6 +6,9 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+# FlatBuffers uses __DATE__ and __TIME__ and it also uses -Werror flag.
+export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
+
 BUILD_TYPE=release
 
 %:

--- a/cpp-linux/debian/rules
+++ b/cpp-linux/debian/rules
@@ -6,6 +6,9 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+# FlatBuffers uses __DATE__ and __TIME__ and it also uses -Werror flag.
+export DEB_BUILD_MAINT_OPTIONS=reproducible=-timeless
+
 BUILD_TYPE=release
 
 %:


### PR DESCRIPTION
Because FlatBuffers uses `__DATE__` and `__TIME__` and it also uses `-Werror` flag.

See also  "timeless" value description of "reproducible" in http://man7.org/linux/man-pages/man1/dpkg-buildflags.1.html .