### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/cpp-linux/apt/debian-stretch/Dockerfile
+++ b/cpp-linux/apt/debian-stretch/Dockerfile
@@ -26,7 +26,7 @@ RUN sed -i'' -e 's/main$/main contrib non-free/g' /etc/apt/sources.list
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     cmake \

--- a/cpp-linux/apt/ubuntu-artful/Dockerfile
+++ b/cpp-linux/apt/ubuntu-artful/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     cmake \

--- a/cpp-linux/apt/ubuntu-bionic/Dockerfile
+++ b/cpp-linux/apt/ubuntu-bionic/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     cmake \

--- a/cpp-linux/apt/ubuntu-trusty/Dockerfile
+++ b/cpp-linux/apt/ubuntu-trusty/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     build-essential \
     cmake3 \
     debhelper\

--- a/cpp-linux/apt/ubuntu-xenial/Dockerfile
+++ b/cpp-linux/apt/ubuntu-xenial/Dockerfile
@@ -24,7 +24,7 @@ ARG DEBUG
 RUN \
   quiet=$([ "${DEBUG}" = "yes" ] || echo "-qq") && \
   apt update ${quiet} && \
-  apt install -y -V ${quiet} \
+  apt-get --no-install-recommends install -y -V ${quiet} \
     autoconf-archive \
     build-essential \
     cmake \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>